### PR TITLE
Filter box size and margin fixes

### DIFF
--- a/styles/SearchFilters.module.css
+++ b/styles/SearchFilters.module.css
@@ -12,8 +12,8 @@
 }
 
 .filter_inner_container{
-    width:585px;
-    margin-left:29px;
+    width:570px;
+    margin-left:10px;
 }
 
 .filter_group{
@@ -38,12 +38,11 @@
 .filterIcon > span{
     cursor:pointer;
     user-select: none;
-    margin-left:10px
 }
 
 @media screen and (max-width:650px) {
     .filter_inner_container{
-        max-width:400px;
+        max-width:435px;
     }
     .search_filter{
         flex-direction: column;
@@ -52,6 +51,6 @@
 
 @media screen and (max-width:450px) {
     .filter_inner_container{
-        max-width:300px;
+        max-width:335px;
     }
 }


### PR DESCRIPTION
Here are two fixes:
- Earlier search filter box's size was small as compared to the filter box. So, the size has been fixed for small devices.
- Left margin for filter box was huge, thus it was reduced.